### PR TITLE
Removed `relref` which is no longer in use.

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -62,4 +62,4 @@ $ export VANTAGE_API_HOST="https://api.vantage.sh"
 
 ## Configuration Options
 
-Use `pulumi config set vantage:<option>` or pass options to the [constructor of `new vantage.Provider`]({{< relref "/registry/packages/vantage/api-docs/provider" >}}).
+Use `pulumi config set vantage:<option>` or pass options to the [constructor of `new vantage.Provider`](/registry/packages/vantage/api-docs/provider).


### PR DESCRIPTION
@jaxxstorm the `relref` fixer is no longer active in `pulumi/registry`. As a result, this would break the link:

https://github.com/pulumi/registry/pull/3884/files

Can you create a new patch release?

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 84a5b3f48579fa5909af308bd3b6f9e6a9ce8cce.  | 
|--------|--------|

### Summary:
This PR removes the inactive `relref` shortcode from a markdown link in `/docs/installation-configuration.md`, preventing the link from breaking.

**Key points**:
- Removed `relref` shortcode from a markdown link in `/docs/installation-configuration.md`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
